### PR TITLE
integrate with huggingface

### DIFF
--- a/models/baseline.py
+++ b/models/baseline.py
@@ -23,7 +23,7 @@ from models.refinement.stem_layer import StemLayer
 class BiRefNet(nn.Module,
                PyTorchModelHubMixin,
                library_name="BiRefNet",
-               repo_url="https://github.com/NeuralCarver/Michelangelo",
+               repo_url="https://github.com/ZhengPeng7/BiRefNet",
                tags=["image-to-image"]
                ):
     def __init__(self, bb_pretrained=True):

--- a/models/baseline.py
+++ b/models/baseline.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 from torchvision.models import vgg16, vgg16_bn
 from torchvision.models import resnet50
 from kornia.filters import laplacian
+from huggingface_hub import PyTorchModelHubMixin
 
 from config import Config
 from dataset import class_labels_TR_sorted
@@ -19,7 +20,12 @@ from models.refinement.refiner import Refiner, RefinerPVTInChannels4, RefUNet
 from models.refinement.stem_layer import StemLayer
 
 
-class BiRefNet(nn.Module):
+class BiRefNet(nn.Module,
+               PyTorchModelHubMixin,
+               library_name="BiRefNet",
+               repo_url="https://github.com/NeuralCarver/Michelangelo",
+               tags=["image-to-image"]
+               ):
     def __init__(self, bb_pretrained=True):
         super(BiRefNet, self).__init__()
         self.config = Config()

--- a/models/baseline.py
+++ b/models/baseline.py
@@ -22,7 +22,7 @@ from models.refinement.stem_layer import StemLayer
 
 class BiRefNet(nn.Module,
                PyTorchModelHubMixin,
-               library_name="BiRefNet",
+               library_name="birefnet",
                repo_url="https://github.com/ZhengPeng7/BiRefNet",
                tags=["image-to-image"]
                ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ prettytable
 scipy
 scikit-image
 kornia
+huggingface_hub>=0.22


### PR DESCRIPTION
I saw this model on huggingface and i thought it would be better to integrate it with using the `PyTorchModelHubLixin` class what this does is that it mainly adds 3 methods to your model : 
* `save_pretrained`
* `from_pretrained`
* `push_to_hub` 

I made a notebook on how to migrate your weights for this specific model which you can find here: https://colab.research.google.com/drive/1iz-g2sOophWy18KxGz_00lGlcKrtafA_?usp=sharing

having the model in its respective repo will allow you to : 
 * Keep track of how many times your model has been downloaded by the community 
 * Automatic model card generation: the metadata in the card allows you to filter your [searches](https://huggingface.co/models?other=BiRefNet) easily to check how many BiRefNet models exist on the Hub.
 * (extra) : if you want to integrate your model with pip i made a little template for that in this repo : https://github.com/not-lain/PyTorchModelHubMixin-template 
 * Recommended: after this pr is merged we can open a pull request [on this file](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) to make the "BiRefNet" library official on the Hub meaning better discoverability + possibility to add code snippets.
 
do not hesitate if you have any reviews on the pr or any questions.

Kind regards,
Hafedh Hichri