### PR TITLE
Fix a bug when resuming training

### DIFF
--- a/train.py
+++ b/train.py
@@ -106,6 +106,7 @@ def init_models_optimizers(epochs, to_be_distributed):
             state_dict = torch.load(args.resume, map_location='cpu')
             state_dict = check_state_dict(state_dict)
             model.load_state_dict(state_dict)
+            global epoch_st
             epoch_st = int(args.resume.rstrip('.pth').split('epoch_')[-1]) + 1
         else:
             logger.info("=> no checkpoint found at '{}'".format(args.resume))


### PR DESCRIPTION
Hi, thanks for your great work! 
I found a minor bug when resuming training. In `train.py`’s `init_models_optimizers` function, `epoch_st` needs a `global` declaration to make resuming work properly.
