### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ prettytable
 scipy
 scikit-image
 kornia
+numpy==1.23.1


### PR DESCRIPTION
Newest numpy is now updated to 2.0.0, which has conflict to torchvision==0.15.2 under linux. Thus, It is necessary to specify a numpy version, which has passed my testing