### PR TITLE
Fix sys_home_dir on windows

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ import math
 class Config():
     def __init__(self) -> None:
         # PATH settings
-        self.sys_home_dir = os.environ['HOME']     # Make up your file system as: SYS_HOME_DIR/codes/dis/BiRefNet, SYS_HOME_DIR/datasets/dis/xx, SYS_HOME_DIR/weights/xx
+        self.sys_home_dir = os.path.expanduser('~')     # Make up your file system as: SYS_HOME_DIR/codes/dis/BiRefNet, SYS_HOME_DIR/datasets/dis/xx, SYS_HOME_DIR/weights/xx
 
         # TASK settings
         self.task = ['DIS5K', 'COD', 'HRSOD', 'DIS5K+HRSOD+HRS10K', 'P3M-10k'][0]


### PR DESCRIPTION
It was crashing here on Windows, as it lacks a `HOME` environment variable (it's `USERPROFILE`).

`os.path.expanduser('~')` correctly returns the home directory on Windows, Linux, and Mac.