### PR TITLE
Fix window_reverse to support batch inference when using onnx or tensorrt

### DIFF
--- a/models/backbones/swin_v1.py
+++ b/models/backbones/swin_v1.py
@@ -64,9 +64,9 @@ def window_reverse(windows, window_size, H, W):
     Returns:
         x: (B, H, W, C)
     """
-    B = int(windows.shape[0] / (H * W / window_size / window_size))
-    x = windows.view(B, H // window_size, W // window_size, window_size, window_size, -1)
-    x = x.permute(0, 1, 3, 2, 4, 5).contiguous().view(B, H, W, -1)
+    C = int(windows.shape[-1])
+    x = windows.view(-1, H // window_size, W // window_size, window_size, window_size, C)
+    x = x.permute(0, 1, 3, 2, 4, 5).contiguous().view(-1, H, W, C)
     return x
 
 


### PR DESCRIPTION
This fix in `window_reverse` is useful when converting to onnx, tensorrt or other models. The change will not affect the pytorch inference or training.
The previous code may lead the converter to regard `B` as a constant value (which  is  `1` in most cases). This will lead to a wrong answer in batch inference. The new code will regard `B` as a dynamic value `-1`.

This PR used the same change in https://github.com/microsoft/Swin-Transformer/pull/257