### PR TITLE
Handle non-RGB Pillow images

### DIFF
--- a/tutorials/BiRefNet_inference-fp16.ipynb
+++ b/tutorials/BiRefNet_inference-fp16.ipynb
@@ -147,6 +147,7 @@
         "for image_path in image_paths:\n",
         "    print('Processing {} ...'.format(image_path))\n",
         "    image = Image.open(image_path)\n",
+        "    image = image.convert(\"RGB\") if image.mode != \"RGB\" else image\n",
         "    input_images = transform_image(image).unsqueeze(0).to(device)\n",
         "    input_images = input_images.half()\n",
         "\n",

--- a/tutorials/BiRefNet_inference.ipynb
+++ b/tutorials/BiRefNet_inference.ipynb
@@ -143,6 +143,7 @@
         "for image_path in image_paths:\n",
         "    print('Processing {} ...'.format(image_path))\n",
         "    image = Image.open(image_path)\n",
+        "    image = image.convert(\"RGB\") if image.mode != \"RGB\" else image\n",
         "    input_images = transform_image(image).unsqueeze(0).to(device)\n",
         "\n",
         "    # Prediction\n",

--- a/tutorials/BiRefNet_inference_video.ipynb
+++ b/tutorials/BiRefNet_inference_video.ipynb
@@ -176,7 +176,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -223,7 +223,8 @@
         "    image_path = image_paths[idx]\n",
         "    if (idx // batch_size + 1) % int(len(image_paths) // batch_size * 0.1) == 0:\n",
         "        print('Processing {} / {} ...'.format(image_path, len(image_paths)))\n",
-        "    input_images_pil = [Image.open(image_path) for image_path in image_paths[idx:idx + batch_size]]\n",
+        "    input_images_pil = [image.convert(\"RGB\") if image.mode != \"RGB\" else image\n",
+        "                        for image in [Image.open(image_path) for image_path in image_paths[idx:idx + batch_size]]]\n",
         "    input_images = [transform_image(input_image).unsqueeze(0).to(device) for input_image in input_images_pil]\n",
         "    input_images = torch.cat(input_images, dim=0)\n",
         "\n",

--- a/tutorials/BiRefNet_inference_video.ipynb
+++ b/tutorials/BiRefNet_inference_video.ipynb
@@ -176,7 +176,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",

--- a/tutorials/BiRefNet_pth2onnx.ipynb
+++ b/tutorials/BiRefNet_pth2onnx.ipynb
@@ -315,6 +315,7 @@
     "\n",
     "imagepath = './Helicopter-HR.jpg'\n",
     "image = Image.open(imagepath)\n",
+    "image = image.convert(\"RGB\") if image.mode != \"RGB\" else image\n",
     "input_images = transform_image(image).unsqueeze(0).to(device)\n",
     "input_images_numpy = input_images.cpu().numpy()"
    ]


### PR DESCRIPTION
Hi, a small PR for the notebook demo when the selected images are not interpreted as RGB images (i.e., 4 channels, etc.) to avoid that kind of error : 

> RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0