### PR TITLE
修复 图像添加高斯噪声的代码bug和可读性

### DIFF
--- a/image_proc.py
+++ b/image_proc.py
@@ -166,7 +166,8 @@ def random_gaussian(image, mean=0.1, sigma=0.35):
         return im
 
     img = np.asarray(image)
-    height, width, channels = img.shape
+    height, width = img.shape[:2]
+    channels = 1 if img.ndim == 2 else img.shape[2]
     img = gaussianNoisy(img[:].flatten(), mean, sigma)
     img = img.reshape([height, width, channels])
     return Image.fromarray(np.uint8(img))


### PR DESCRIPTION
why:
原仓库训练代码里没有使用 添加高斯噪声的数据增强方式，而是椒盐噪声；若使用添加高斯噪声去数据增强，则训练代码会报错

tofix:
image_proc.py 中的random_gaussian函数里
1）第171行img = img.reshape([width, height]) 应该加入图像的通道数判断，然后修改为：img = img.reshape([height, width, channels]) 
2) 虽然random_gaussian函数里，img 的尺寸为1024x1024，width 和 height 相同；但是代码里的 width, height = img.shape 表述有歧义，如果config.py 里的size设置了宽和高不一样的尺寸，容易导致bug，应该写为 height, width  = img.shape[:2]

test code:

# -*- coding: utf-8 -*-
import cv2 
import random 
import numpy as np 
from PIL import Image


def random_gaussian(image, mean=0.1, sigma=0.35):
    def gaussianNoisy(im, mean=mean, sigma=sigma):
        for _i in range(len(im)):
            im[_i] += random.gauss(mean, sigma)
        return im

    img = np.asarray(image)
    height, width = img.shape[:2]
    channels = 1 if img.ndim == 2 else img.shape[2]
    img = gaussianNoisy(img[:].flatten(), mean, sigma)
    img = img.reshape([height, width, channels])
    return Image.fromarray(np.uint8(img))


if __name__ == '__main__':
    image = cv2.imread('./images/test.jpg')
    size = (1024, 1024)
    image = cv2.resize(image, size, interpolation=cv2.INTER_LINEAR)
    image = Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB)).convert('RGB')
    gaussian_image = random_gaussian(image)
    gaussian_image.save("./images/test_gaussian.png")